### PR TITLE
Femiwikiskin URL and name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -284,7 +284,7 @@
 	path = Sanctions
 	url = https://github.com/femiwiki/Sanctions
 [submodule "Femwiki"]
-	path = Femwiki
+	path = FemiwikiSkin
 	url = https://github.com/femiwiki/skin
 [submodule "RottenLinks"]
 	path = RottenLinks

--- a/.gitmodules
+++ b/.gitmodules
@@ -285,7 +285,7 @@
 	url = https://github.com/femiwiki/Sanctions
 [submodule "Femwiki"]
 	path = FemiwikiSkin
-	url = https://github.com/femiwiki/skin
+	url = https://github.com/femiwiki/FemiwikiSkin
 [submodule "RottenLinks"]
 	path = RottenLinks
 	url = https://github.com/miraheze/RottenLinks


### PR DESCRIPTION
Fem(missing **i**)wiki is obviously inaccurate name. Since skin name was changed to [`FemiwikiSkin`](https://github.com/femiwiki/FemiwikiSkin), use that instead.

Keeping submodule name (`[submodule "Femwiki"]` part) because I am not a git guru and I fear there might be unintended side effect if I touch something. Feel free to fix it when/after merging.