### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -664,3 +664,6 @@
 [submodule "TablesInSematic"]
 	path = TablesInSematic
 	url = https://github.com/Wikifab/TablesInSemantic.git
+[submodule "Shariff-Mediawiki"]
+	path = Shariff-Mediawiki
+	url = https://github.com/vonloxley/Shariff-Mediawiki.git


### PR DESCRIPTION
Shariff is a set of social media sharing buttons that are EU privacy compliant. Extension is somewhat out of date, but developer promised to get it running with MW 1.35