### PR TITLE
Add new Nonsensopedia extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -403,6 +403,18 @@
 [submodule "FancyModeration"]
 	path = FancyModeration
 	url = https://gitlab.com/nonsensopedia/extensions/fancymoderation.git/
+[submodule "NonsaLinks"]
+    path = NonsaLinks
+    url = https://gitlab.com/nonsensopedia/extensions/nonsalinks
+[submodule "ResponsiveFrontend"]
+    path = ResponsiveFrontend
+    url = https://gitlab.com/nonsensopedia/extensions/responsivefrontend
+[submodule "SemanticCommonsClient"]
+    path = SemanticCommonsClient
+    url = https://gitlab.com/nonsensopedia/extensions/semanticcommonsclient
+[submodule "NonsaCodeJanitor"]
+    path = NonsaCodeJanitor
+    url = https://gitlab.com/nonsensopedia/extensions/nonsacodejanitor
 [submodule "MigrateMyLinks"]
 	path = MigrateMyLinks
 	url = https://github.com/ciencia/mediawiki-extensions-MigrateMyLinks.git


### PR DESCRIPTION
- ResponsiveFrontend is a semi-experimental extension for adding responsive versions of core features. Currently supports responsive diffs.
- SemanticCommonsClient is an SMW extension for retrieving image metadata from Wikimedia Commons and Wikidata.
- NonsaCodeJanitor and NonsaLinks are project-specific extensions for tweaking MW's behavior to match the community's expectations. Not sure if they should be added to MWStake repo or not.