### PR TITLE
Remove super legacy Brickimedia extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -682,27 +682,6 @@
 [submodule "Shariff-Mediawiki"]
 	path = Shariff-Mediawiki
 	url = https://github.com/vonloxley/Shariff-Mediawiki.git
-[submodule "Answers"]
-	path = Answers
-	url = https://github.com/Brickimedia/Answers
-[submodule "ARE"]
-	path = ARE
-	url = https://github.com/Brickimedia/ARE
-[submodule "GlobalContribs"]
-	path = GlobalContribs
-	url = https://github.com/Brickimedia/GlobalContribs
-[submodule "NewTalkGlobal"]
-	path = NewTalkGlobal
-	url = https://github.com/Brickimedia/NewTalkGlobal
-[submodule "NumberOfComments"]
-	path = NumberOfComments
-	url = https://github.com/Brickimedia/NumberOfComments
-[submodule "Snippet"]
-	path = Snippet
-	url = https://github.com/Brickimedia/Snippet
-[submodule "USERNAME"]
-	path = USERNAME
-	url = https://github.com/Brickimedia/USERNAME
 [submodule "MediaWikiAuth"]
 	path = MediaWikiAuth
 	url = https://github.com/SkizNet/mediawiki-MediaWikiAuth


### PR DESCRIPTION
Per my comment at #25, these are either obsolete or the current version is maintained on WMF git/gerrit. Either way, these GitHub repos aren't used and haven't been used since 2017.

cc @hexmode