### PR TITLE
Remove the CentralCheckUser submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -328,9 +328,6 @@
 [submodule "Moderation"]
 	path = Moderation
 	url = https://github.com/edwardspec/mediawiki-moderation.git
-[submodule "CentralCheckUser"]
-	path = CentralCheckUser
-	url = https://github.com/examknow/CentralCheckUser.git
 [submodule "BCmath"]
 	path = BCmath
 	url = https://github.com/jeblad/BCmath.git


### PR DESCRIPTION
Repository is marked as read-only, and it keeps appearing on https://codesearch.wmcloud.org.

I found it while I was trying to find a repository for which I could make patches per https://phabricator.wikimedia.org/T220036