### PR TITLE
Remove DataMaps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -190,9 +190,6 @@
 [submodule "DataDump"]
 	path = DataDump
 	url = https://github.com/miraheze/DataDump
-[submodule "DataMaps"]
-	path = DataMaps
-	url = https://github.com/alex4401/mediawiki-extensions-DataMaps.git
 [submodule "DataProvider"]
 	path = DataProvider
 	url = https://github.com/vit1251/mediawiki-extensions-DataProvider.git


### PR DESCRIPTION
Repository was [moved to Gerrit](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/DataMaps). [Extension page](https://www.mediawiki.org/wiki/Extension:DataMaps) was updated with the new repository, and Codesearch currently lists both the old and new repositories in search results.